### PR TITLE
Use finer grained timeseries over shorter range

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -5,7 +5,7 @@ from dask.distributed import Client, wait
 
 if __name__ == "__main__":
     client = Client("127.0.0.1:8786")
-    ddf_h = timeseries(start='2000-01-01', end='2001-01-01', partition_freq='1d')
+    ddf_h = timeseries(start='2000-01-01', end='2000-01-02', partition_freq='1min')
     result = shuffle(ddf_h, "id", shuffle="tasks")
     ddf = client.persist(result)
     _ = wait(ddf)


### PR DESCRIPTION
To put Dask through the paces a bit more and get better resolution on the scheduler itself (as opposed to cluster startup), use a smaller range and divide finely.