### PR TITLE
Repeat computation for 20 iterations

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -7,7 +7,9 @@ if __name__ == "__main__":
     client = Client("127.0.0.1:8786")
     ddf_h = timeseries(start='2000-01-01', end='2000-01-02', partition_freq='1min')
     result = shuffle(ddf_h, "id", shuffle="tasks")
-    ddf = client.persist(result)
-    _ = wait(ddf)
+    for i in range(20):
+        ddf = client.persist(result)
+        _ = wait(ddf)
+        client.cancel(ddf)
     client.shutdown()
     time.sleep(0.5)


### PR DESCRIPTION
This adds a `for`-loop around the `persist` & `wait` step. Also calls `client.cancel` on the futures after completion. This allows for multiple runs doing the same computation and thus better resolution into the slow steps when profiling.