### PR TITLE
Add step to Cythonize parts of Distributed

### DIFF
--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -19,6 +19,13 @@ ENV="$TODAY-nightly-0.17"
 conda activate $ENV
 which python
 
+echo "Cythonize Distributed"
+pushd "${CONDA_PREFIX}/lib/python3.8/site-packages/"
+cythonize -i \
+	"distributed/protocol/serialize.py"
+	"distributed/scheduler.py"
+popd
+
 srun -N1 python nightly-run.py > dgx_raw_data.txt
 echo "Copy sitecustomize.py..."
 cp sitecustomize.py ${CONDA_PREFIX}/lib/python3.8/sitecustomize.py


### PR DESCRIPTION
Adds a step to the nightly benchmarks to Cythonize some modules in Distributed in-place. We go ahead and do this in the environment's `site-packages` as this environment exists for this benchmark work. So altering it this way shouldn't present an issue.