### PR TITLE
Enable profiling of Cython functions

### DIFF
--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -21,7 +21,7 @@ which python
 
 echo "Cythonize Distributed"
 pushd "${CONDA_PREFIX}/lib/python3.8/site-packages/"
-cythonize -i \
+cythonize -i --directive="profile=True" \
 	"distributed/protocol/serialize.py" \
 	"distributed/scheduler.py" \
 


### PR DESCRIPTION
As it is not possible to profile Cython functions by default, this adds a few options to ensure that Cython compiles these functions with profiling support enabled. This way we should now be able to see how long they take with cProfile as used in our nightly benchmarks.