### PR TITLE
Use Cython's Python 3 mode and force recompilation

### DIFF
--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -21,7 +21,7 @@ which python
 
 echo "Cythonize Distributed"
 pushd "${CONDA_PREFIX}/lib/python3.8/site-packages/"
-cythonize -i --directive="profile=True" \
+cythonize -i -3 --directive="profile=True" \
 	"distributed/protocol/serialize.py" \
 	"distributed/scheduler.py" \
 

--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -21,7 +21,7 @@ which python
 
 echo "Cythonize Distributed"
 pushd "${CONDA_PREFIX}/lib/python3.8/site-packages/"
-cythonize -i -3 --directive="profile=True" \
+cythonize -f -i -3 --directive="profile=True" \
 	"distributed/protocol/serialize.py" \
 	"distributed/scheduler.py" \
 


### PR DESCRIPTION
* Use Python 3 for builds (Cython `0.x` defaults to Python 2; next Cython major release will be Python 3)
* Force recompilation of Cython code (useful in case there are lingering `*.so`s).