### PR TITLE
Drop Cythonization step

### DIFF
--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -19,13 +19,6 @@ ENV="$TODAY-nightly-0.17"
 conda activate $ENV
 which python
 
-echo "Cythonize Distributed"
-pushd "${CONDA_PREFIX}/lib/python3.8/site-packages/"
-cythonize -f -i -3 --directive="profile=True" \
-	"distributed/scheduler.py" \
-
-popd
-
 srun -N1 python nightly-run.py > dgx_raw_data.txt
 echo "Copy sitecustomize.py..."
 cp sitecustomize.py ${CONDA_PREFIX}/lib/python3.8/sitecustomize.py


### PR DESCRIPTION
Requires PR ( https://github.com/quasiben/dask-cuda-benchmarks/pull/45 )

We are moving this upstream in the build process. So don't need it here any more.