### PR TITLE
Add y-label

### DIFF
--- a/nightly-benchmark/nightly-run.py
+++ b/nightly-benchmark/nightly-run.py
@@ -120,6 +120,7 @@ if __name__ == "__main__":
         parse_dates=["date"],
         names=["date", "operation", "avg", "std"],
     )
+    ax[0].set_ylabel("Time (s)")
     for idx, (key, group) in enumerate(df.groupby("operation")):
         ax[idx].set_title(f"{key}")
         ax[idx].errorbar(group.date, group.avg, yerr=group["std"].values)

--- a/nightly-benchmark/publish_benchmark.py
+++ b/nightly-benchmark/publish_benchmark.py
@@ -47,7 +47,7 @@ repo.create_file(
 
 print("Creating Issue...")
 template = f"""
-## Historical Throughput
+## Benchmark history
 <img width="641" alt="Benchmark Image"
 src="https://raw.githubusercontent.com/quasiben/dask-scheduler-performance/benchmark-images/assets/{fname_hist}">
 


### PR DESCRIPTION
**What does this PR do?**

1. It adds a ylabel: "Time (s)".
    * That's a lot more clear than the label about the graph, "historical throughput" because throughput is the inverse of completion time.
2. I've also renamed the header to be "historical benchmarks"
    * Now, it's clear that the shown graph is not a visualization of historical measurements of Dask throughput.

I made this change through GitHub's web interface, so it's not tested.