### PR TITLE
Add a config file for Dask

### DIFF
--- a/dask.yaml
+++ b/dask.yaml
@@ -1,0 +1,15 @@
+optimization:
+  fuse:
+    active: false
+
+distributed:
+  version: 2
+  worker:
+    profile:
+      interval: 10s        # Time between statistical profiling queries
+      cycle: 1000s         # Time between starting new profile
+      low-level: false     # Whether or not to include low-level functions
+  admin:
+    event-loop: uvloop
+    system-monitor:
+      interval: 1h

--- a/nightly-benchmark/run-dgx-benchmark.sh
+++ b/nightly-benchmark/run-dgx-benchmark.sh
@@ -22,7 +22,7 @@ which python
 srun -N1 python nightly-run.py > dgx_raw_data.txt
 echo "Copy sitecustomize.py..."
 cp sitecustomize.py ${CONDA_PREFIX}/lib/python3.8/sitecustomize.py
-export DASK_OPTIMIZATION__FUSE__ACTIVE=False
+export DASK_CONFIG="../dask.yaml"
 srun -N1 bash run-shuffle.sh
 srun -N1 python publish_benchmark.py
 echo "Clean up sitecustomize.py..."


### PR DESCRIPTION
Switches to [using a config file]( https://docs.dask.org/en/latest/configuration.html#specify-configuration ) for running Dask. Allows using `uvloop`, disables Distributed's profiling, and enables fusing.

xref: https://github.com/quasiben/dask-cuda-benchmarks/pull/81

cc @mrocklin