### PR TITLE
[NO MRG] Try Rick's example in the benchmark

### DIFF
--- a/nightly-benchmark/shuffle.py
+++ b/nightly-benchmark/shuffle.py
@@ -6,12 +6,13 @@ from dask.distributed import Client, wait
 if __name__ == "__main__":
     client = Client("127.0.0.1:8786")
     ddf_h = timeseries(start='2000-01-01', end='2000-01-02', partition_freq='1min')
-    for i in range(5):
+    for i in range(20):
         print("Iteration: ", i)
-        result = shuffle(ddf_h, "id", shuffle="tasks")
-        ddf = client.persist(result)
-        _ = wait(ddf)
-        client.cancel(ddf)
-        client.cancel(result)
+        s = ddf_h["id"] + 10
+        mean = s.mean()
+        mean = client.persist(mean)
+        _ = wait(mean)
+        client.cancel(mean)
+        client.cancel(s)
     client.shutdown()
     time.sleep(0.5)


### PR DESCRIPTION
**Note:** This is merely intended to be illustrative. No need for merging

This tries @rjzamora's example ( https://github.com/dask/dask/pull/7615#issuecomment-828001438 ) as shown in the diff below. So is a follow up to the profile in issue ( https://github.com/quasiben/dask-scheduler-performance/issues/137 ).

To make this more comparable to existing work with `shuffle`, this makes a couple of notable tweaks to Rick's example. First it uses the same input data that is used with `shuffle`. However this doesn't show much in a single (or even a few) iterations. So this does 20 iterations instead of the typical 5 iterations with `shuffle`.

With these modifications, this starts to look more analogous to the results that we see in a normal `shuffle` like in issue ( https://github.com/quasiben/dask-scheduler-performance/issues/140 ) (even though this is not a `shuffle`). Namely time is spent mostly in communication followed by finished task transitions. IOW backing up what was found before ( https://github.com/quasiben/dask-scheduler-performance/issues/139#issuecomment-832950127 ).

![prof_29970 pstat dot](https://user-images.githubusercontent.com/3019665/117356341-75231f80-ae68-11eb-9f8e-d07edd337329.png)

cc @quasiben