### PR TITLE
Disable Python Garbage Collection

### DIFF
--- a/nightly-benchmark/sitecustomize.py
+++ b/nightly-benchmark/sitecustomize.py
@@ -1,8 +1,14 @@
 import atexit
 import cProfile
+import gc
 import os
 import sys
 import uuid
+
+
+gc.disable()
+gc.set_threshold(0)
+
 
 if not os.path.basename(sys.argv[0]).startswith("gprof2dot"):
     p = cProfile.Profile()


### PR DESCRIPTION
There doesn't appear to be an environment variable to disable Garbage Collection. So this disables Garbage Collection in `sitecustomize.py` to ensure it is off at process startup. Though we will need to reinstall this file on the machine running the benchmarks to get it to work